### PR TITLE
Send-receive

### DIFF
--- a/applications/oslc_prolog_server.pl
+++ b/applications/oslc_prolog_server.pl
@@ -19,6 +19,7 @@ limitations under the License.
 :- use_module(library(semweb/rdf11)).
 :- use_module(library(http/thread_httpd)).
 :- use_module(library(http/http_client)).
+:- use_module(library(http/http_header)).
 :- use_module(library(http/http_dispatch)).
 :- use_module(library(broadcast)).
 :- use_module(library(oslc_dispatch)).
@@ -194,7 +195,7 @@ read_request_body(Request, GraphIn) :-
   ContentLength > 0,
   once((
     memberchk(content_type(InContentType), Request),
-    http_header:http_parse_header_value(content_type, InContentType, media(SerializerType, _)),
+    http_parse_header_value(content_type, InContentType, media(SerializerType, _)),
     oslc_dispatch:serializer(SerializerType, Format)
   ; throw(response(415)) % unsupported media type
   )),

--- a/lib/oslc_client.pl
+++ b/lib/oslc_client.pl
@@ -15,7 +15,8 @@ limitations under the License.
 */
 
 :- module(oslc_client, [post_graph/3,
-                        post_resource/3
+                        post_resource/3,
+                        post_resource/4
                        ]).
 
 :- use_module(library(semweb/rdf11)).
@@ -23,31 +24,33 @@ limitations under the License.
 :- use_module(library(oslc)).
 :- use_module(library(oslc_rdf)).
 
-:- rdf_meta post_resource(r, -),
-            post_resource(r, -, -).
+:- rdf_meta post_resource(r, -, -),
+            post_resource(r, -, -, -).
 
-:- predicate_options(post_graph/3, 3, [content_type(any)]).
+:- predicate_options(post_graph/3, 3, [content_type(any), headers(any), to(any)]).
 :- predicate_options(post_resource/3, 3, [content_type(any), graph(atom)]).
+:- predicate_options(post_resource/4, 3, [content_type(any), graph(atom)]).
 
 post_graph(Graph, URI, Options) :-
   must_be(atom, Graph),
   option(content_type(ContentType), Options, text/turtle),
+  merge_options(Options, 
+                [ status_code(StatusCode),     
+                  request_header('Accept'='text/turtle,application/rdf+xml,application/n-triples')
+                ], Options1),
   oslc_dispatch:serializer(ContentType, Serializer),
   setup_call_cleanup(
     new_memory_file(File), (
       open_memory_file(File, write, Out),
       oslc_dispatch:serialize_response(stream(Out), Graph, Serializer),
       close(Out),
-      http_post(URI, memory_file(ContentType, File), _,
-                [ status_code(StatusCode),
-                  request_header('Accept'='text/turtle,application/rdf+xml,application/n-triples')
-                ]),
+      http_post(URI, memory_file(ContentType, File), _, Options1),
       StatusCode == 200
     ),
     free_memory_file(File)
   ).
 
-post_resource(IRI, URI, Options) :-
+post_resource(IRI, URI, Options, ResponseGraph) :-
   option(graph(Graph), Options, _),
   setup_call_catcher_cleanup(
     make_temp_graph(Tmp),
@@ -56,8 +59,44 @@ post_resource(IRI, URI, Options) :-
       -> copy_resource(IRI, IRI, rdf, rdf(Tmp), Options)
       ; copy_resource(IRI, IRI, rdf(Graph), rdf(Tmp), Options)
       ),
-      post_graph(Tmp, URI, Options)
+      setup_call_cleanup(
+        new_memory_file(File), (
+          open_memory_file(File, write, Response, [encoding(octet)]),
+          merge_options([headers(Fields), to(stream(Response))], Options, Options1),
+          post_graph(Tmp, URI, Options1),
+          close(Response),
+          open_memory_file(File, read, Stream, [encoding(utf8)]),
+          ( atom(ResponseGraph) -> read_response_body(Fields, Stream, ResponseGraph) 
+          ; true ),
+          close(Stream)
+        ),
+        free_memory_file(File)
+      )
     ),
     _,
     delete_temp_graph(Tmp)
   ).
+
+post_resource(IRI, URI, Options) :- post_resource(IRI, URI, Options, _).
+
+read_response_body(Fields, Stream, GraphOut) :-
+  once((
+    is_list(Fields),
+    must_be(atom, GraphOut),
+    rdf_graph(GraphOut),
+    memberchk(content_length(ContentLength), Fields), % if there is response, try to parse it
+    ContentLength > 0,
+    memberchk(content_type(InContentType), Fields),
+    http_header:http_parse_header_value(content_type, InContentType, media(SerializerType, _)),
+    oslc_dispatch:serializer(SerializerType, Format),
+    catch((
+        rdf_load(stream(Stream), [graph(GraphOut), format(Format), silent(true), on_error(error), cache(false)])
+      ),
+      error(E, stream(Stream, Line, Column, _)),
+      (
+        message_to_string(error(E, _), S),
+        format(atom(Message), 'Parsing error (line ~w, column ~w): ~w.', [Line, Column, S]),
+        throw(response(400, Message)) % bad request
+      )
+    )
+  )).

--- a/lib/oslc_client.pl
+++ b/lib/oslc_client.pl
@@ -15,88 +15,84 @@ limitations under the License.
 */
 
 :- module(oslc_client, [post_graph/3,
-                        post_resource/3,
-                        post_resource/4
+                        post_resource/3
                        ]).
 
 :- use_module(library(semweb/rdf11)).
 :- use_module(library(http/http_client)).
+:- use_module(library(http/http_header)).
 :- use_module(library(oslc)).
 :- use_module(library(oslc_rdf)).
 
-:- rdf_meta post_resource(r, -, -),
-            post_resource(r, -, -, -).
+:- rdf_meta post_resource(r, -, -).
 
 :- predicate_options(post_graph/3, 3, [content_type(any), headers(any), to(any)]).
-:- predicate_options(post_resource/3, 3, [content_type(any), graph(atom)]).
-:- predicate_options(post_resource/4, 3, [content_type(any), graph(atom)]).
+:- predicate_options(post_resource/3, 3, [content_type(any), graph(atom), response_graph(atom)]).
 
 post_graph(Graph, URI, Options) :-
   must_be(atom, Graph),
   option(content_type(ContentType), Options, text/turtle),
-  merge_options(Options, 
-                [ status_code(StatusCode),     
-                  request_header('Accept'='text/turtle,application/rdf+xml,application/n-triples')
-                ], Options1),
   oslc_dispatch:serializer(ContentType, Serializer),
+  term_to_atom(ContentType, PostContentType),
+  merge_options([ content_type(PostContentType),
+                  status_code(200),
+                  request_header('Accept'='text/turtle,application/rdf+xml,application/n-triples')
+                ], Options, Options1),
   setup_call_cleanup(
     new_memory_file(File), (
       open_memory_file(File, write, Out),
       oslc_dispatch:serialize_response(stream(Out), Graph, Serializer),
       close(Out),
-      http_post(URI, memory_file(ContentType, File), _, Options1),
-      StatusCode == 200
+      http_post(URI, memory_file(ContentType, File), _, Options1)
     ),
     free_memory_file(File)
   ).
 
-post_resource(IRI, URI, Options, ResponseGraph) :-
+post_resource(IRI, URI, Options) :-
   option(graph(Graph), Options, _),
-  setup_call_catcher_cleanup(
+  setup_call_cleanup(
     make_temp_graph(Tmp),
     (
       ( var(Graph)
       -> copy_resource(IRI, IRI, rdf, rdf(Tmp), Options)
       ; copy_resource(IRI, IRI, rdf(Graph), rdf(Tmp), Options)
       ),
-      setup_call_cleanup(
-        new_memory_file(File), (
-          open_memory_file(File, write, Response, [encoding(octet)]),
-          merge_options([headers(Fields), to(stream(Response))], Options, Options1),
-          post_graph(Tmp, URI, Options1),
-          close(Response),
-          open_memory_file(File, read, Stream, [encoding(utf8)]),
-          ( atom(ResponseGraph) -> read_response_body(Fields, Stream, ResponseGraph) 
-          ; true ),
-          close(Stream)
-        ),
-        free_memory_file(File)
+      ( option(response_graph(ResponseGraph), Options)
+      -> must_be(atom, ResponseGraph),
+         setup_call_cleanup(
+           new_memory_file(File), (
+             open_memory_file(File, write, Response, [encoding(octet)]),
+             merge_options([headers(Fields), to(stream(Response))], Options, Options1),
+             post_graph(Tmp, URI, Options1),
+             close(Response),
+             open_memory_file(File, read, Stream, [encoding(utf8)]),
+             ignore(read_response_body(Fields, Stream, ResponseGraph)),
+             close(Stream)
+           ),
+           free_memory_file(File)
+         )
+      ; post_graph(Tmp, URI, Options)
       )
     ),
-    _,
     delete_temp_graph(Tmp)
   ).
 
-post_resource(IRI, URI, Options) :- post_resource(IRI, URI, Options, _).
-
 read_response_body(Fields, Stream, GraphOut) :-
-  once((
-    is_list(Fields),
-    must_be(atom, GraphOut),
-    rdf_graph(GraphOut),
-    memberchk(content_length(ContentLength), Fields), % if there is response, try to parse it
-    ContentLength > 0,
-    memberchk(content_type(InContentType), Fields),
-    http_header:http_parse_header_value(content_type, InContentType, media(SerializerType, _)),
-    oslc_dispatch:serializer(SerializerType, Format),
-    catch((
-        rdf_load(stream(Stream), [graph(GraphOut), format(Format), silent(true), on_error(error), cache(false)])
-      ),
-      error(E, stream(Stream, Line, Column, _)),
-      (
-        message_to_string(error(E, _), S),
-        format(atom(Message), 'Parsing error (line ~w, column ~w): ~w.', [Line, Column, S]),
-        throw(response(400, Message)) % bad request
-      )
+  memberchk(content_length(ContentLength), Fields), % if there is response, try to parse it
+  ContentLength > 0,
+  memberchk(content_type(InContentType), Fields),
+  http_parse_header_value(content_type, InContentType, media(SerializerType, _)),
+  oslc_dispatch:serializer(SerializerType, Format),
+  catch(
+    rdf_load(stream(Stream), [graph(GraphOut), format(Format), silent(true), on_error(error), cache(false)]),
+    error(E, stream(Stream, Line, Column, _)),
+    (
+      message_to_string(error(E, _), S),
+      print_message(error, response_parsing_error(Line, Column, S))
     )
-  )).
+  ).
+
+:- multifile prolog:message/3.
+
+prolog:message(response_parsing_error(Line, Column, S)) -->
+  [ 'Response parsing error (line ~w, column ~w): ~w'-[Line, Column, S] ].

--- a/lib/oslc_lisp.pl
+++ b/lib/oslc_lisp.pl
@@ -38,10 +38,3 @@ lisp:func([send, IRI, URI], Result) :- !,
 
 lisp:func([send, IRI, URI, Options], Result) :- !,
   lisp:result(oslc_client:post_resource(IRI, URI, Options), Result).
-
-lisp:func([send_receive, IRI, URI, GraphOut], Result) :- !,
-  lisp:result(oslc_client:post_resource(IRI, URI, [response_graph(GraphOut)]), Result).
-
-lisp:func([send_receive, IRI, URI, GraphOut, Options], Result) :- !,
-  merge_options([response_graph(GraphOut)], Options, Options1),
-  lisp:result(oslc_client:post_resource(IRI, URI, Options1), Result).

--- a/lib/oslc_lisp.pl
+++ b/lib/oslc_lisp.pl
@@ -38,3 +38,13 @@ lisp:func([send, IRI, URI], Result) :- !,
 
 lisp:func([send, IRI, URI, Options], Result) :- !,
   lisp:result(oslc_client:post_resource(IRI, URI, Options), Result).
+
+lisp:func([send_receive, IRI, URI, GraphOut], Result) :- !,
+  marker,
+  lisp:result(oslc_client:post_resource(IRI, URI, [], GraphOut), Result).
+
+lisp:func([send_receive, IRI, URI, GraphOut, Options], Result) :- !,
+  marker,
+  lisp:result(oslc_client:post_resource(IRI, URI, Options, GraphOut), Result).
+
+marker.

--- a/lib/oslc_lisp.pl
+++ b/lib/oslc_lisp.pl
@@ -40,7 +40,8 @@ lisp:func([send, IRI, URI, Options], Result) :- !,
   lisp:result(oslc_client:post_resource(IRI, URI, Options), Result).
 
 lisp:func([send_receive, IRI, URI, GraphOut], Result) :- !,
-  lisp:result(oslc_client:post_resource(IRI, URI, [], GraphOut), Result).
+  lisp:result(oslc_client:post_resource(IRI, URI, [response_graph(GraphOut)]), Result).
 
 lisp:func([send_receive, IRI, URI, GraphOut, Options], Result) :- !,
-  lisp:result(oslc_client:post_resource(IRI, URI, Options, GraphOut), Result).
+  merge_options([response_graph(GraphOut)], Options, Options1),
+  lisp:result(oslc_client:post_resource(IRI, URI, Options1), Result).

--- a/lib/oslc_lisp.pl
+++ b/lib/oslc_lisp.pl
@@ -38,3 +38,9 @@ lisp:func([send, IRI, URI], Result) :- !,
 
 lisp:func([send, IRI, URI, Options], Result) :- !,
   lisp:result(oslc_client:post_resource(IRI, URI, Options), Result).
+
+lisp:func([send_graph, Graph, URI], Result) :- !,
+  lisp:result(oslc_client:post_graph(Graph, URI, []), Result).
+
+lisp:func([send_graph, Graph, URI, Options], Result) :- !,
+  lisp:result(oslc_client:post_graph(Graph, URI, Options), Result).

--- a/lib/oslc_lisp.pl
+++ b/lib/oslc_lisp.pl
@@ -40,11 +40,7 @@ lisp:func([send, IRI, URI, Options], Result) :- !,
   lisp:result(oslc_client:post_resource(IRI, URI, Options), Result).
 
 lisp:func([send_receive, IRI, URI, GraphOut], Result) :- !,
-  marker,
   lisp:result(oslc_client:post_resource(IRI, URI, [], GraphOut), Result).
 
 lisp:func([send_receive, IRI, URI, GraphOut, Options], Result) :- !,
-  marker,
   lisp:result(oslc_client:post_resource(IRI, URI, Options, GraphOut), Result).
-
-marker.


### PR DESCRIPTION
Add reading the response on post_resource and send-receive lisp predicate.

Error handling at line 95 is missing (https://github.com/EricssonResearch/oslc_prolog/compare/send-receive?expand=1#diff-c90a957464a5886bdfb2bd5c11938aa9R95) 