### PR TITLE
Use  base vocabulary to simplify the layout

### DIFF
--- a/lib/oslc_jsonld.pl
+++ b/lib/oslc_jsonld.pl
@@ -73,6 +73,7 @@ convert_po(P0, P, O0, O, C0, C, Graph) :-
   convert_resource(P0, P, C0, C1),
   convert_o(O0, O, C1, C, Graph).
 
+convert_o(^^(B, 'http://www.w3.org/2001/XMLSchema#boolean'), @(B), C, C, _) :- !.
 convert_o(^^(O, _), O, C, C, _) :- !.
 convert_o(@(O, _), O, C, C, _) :- !.
 convert_o(O0, O, C0, C, Graph) :-

--- a/lib/oslc_jsonld.pl
+++ b/lib/oslc_jsonld.pl
@@ -93,22 +93,15 @@ convert_resource(R0, R, C0, C) :-
   ( get_dict('@vocab', C0, Vocab)
   -> ( Vocab = PrefixIRI
      -> R = Local, C = C0
-     ;  format(atom(R), '~w:~w', [Prefix, Local]), 
-        C = C0.put(Prefix, PrefixIRI) 
+     ;  format(atom(R), '~w:~w', [Prefix, Local]),
+        C = C0.put(Prefix, PrefixIRI)
      )
   ; Vocab = _{'@vocab': PrefixIRI},
     C = C0.put(Vocab),
     R = Local
   ).
 % No prefix exists
-convert_resource(R, R, C, C) :-
-  rdf_global_id(_, R).
-
-% Other option is to store full @ids for each property in the context and use short names in the object.
-% Downside is that context gets large -> could be referenced on a separate URI, see https://www.w3.org/2018/jsonld-cg-reports/json-ld/#the-context
-  % Def = _{'@id': R0},
-  % R = Local,
-  % C = C0.put(Local, Def).
+convert_resource(R, R, C, C).
 
 convert_list_o([], [], C, C, _) :- !.
 convert_list_o([H0|T0], [H|T], C0, C, Graph) :-


### PR DESCRIPTION
Make the result look more like plain JSON to make it easier to parse. 
Downside:
- may be dependent on the order of triples (probably, have to check),
- serialize/deserialize are currently incompatible.